### PR TITLE
Add observers to tone-object

### DIFF
--- a/src/Tone.d.ts
+++ b/src/Tone.d.ts
@@ -12,6 +12,7 @@ type Tone = {
   Player: PlayerConstructor;
   gainToDb(gain: number): number;
   Event: ToneEventConstructor<any>;
+  Emitter: Emitter<Object | Function>;
 };
 
 type BarsBeatsSixteenths = string;
@@ -121,4 +122,16 @@ interface IToneEvent<T> {
 
 interface ToneEventConstructor<T> {
   new(callback: (value: T) => void, value?: T): IToneEvent<T>;
+}
+
+interface IEmitter<EventTypes, FArgs> { // TODO no varaidic args, so this is too restrictive
+  dispose(): this;
+  emit(event: EventTypes, ...args: FArgs[]): this;
+  off(event: EventTypes, callback?: (...args: FArgs[]) => void): this;
+  on(event: EventTypes, callback: (...args: FArgs[]) => void): this;
+}
+
+interface Emitter<T> {
+  new(): IEmitter<string, any>;
+  mixin(obj: T): T & IEmitter<string, any>;
 }

--- a/src/Tone.d.ts
+++ b/src/Tone.d.ts
@@ -105,7 +105,7 @@ interface Player {
 }
 
 interface IToneEvent<T> {
-  callback: (value: T) => void;
+  callback: (time: number, value: T) => void;
   loop: boolean;
   loopEnd: number;
   loopStart: number;
@@ -121,7 +121,7 @@ interface IToneEvent<T> {
 }
 
 interface ToneEventConstructor<T> {
-  new(callback: (value: T) => void, value?: T): IToneEvent<T>;
+  new(callback: (time: number, value: T) => void, value?: T): IToneEvent<T>;
 }
 
 interface IEmitter<EventTypes, FArgs> { // TODO no varaidic args, so this is too restrictive

--- a/src/life-cycle.ts
+++ b/src/life-cycle.ts
@@ -149,7 +149,19 @@ export class ManagedAudioEvent implements IAudioEvent {
       Tone.Transport.seconds : preLoadTime
     );
     this.scheduled.set('connect', connectAndScheduleToPlay);
-    this.emit('playing', Tone.Transport.seconds);
+    // naively fire events which ought to align with when the player starts and stops
+    const isPlaying = new Event(time => {
+      this.emit('playing', time);
+      isPlaying.stop();
+    });
+    const hasStopped = new Event(time => {
+      this.emit('stopped', time);
+      hasStopped.stop();
+    });
+    this.scheduled.set('playing', isPlaying);
+    this.scheduled.set('stopped', hasStopped);
+    isPlaying.start(this.startTimeSecs);
+    hasStopped.start(this.startTimeSecs + this.durationSecs);
   }
   
   set(param: Parameter, value: number): void {

--- a/src/life-cycle.ts
+++ b/src/life-cycle.ts
@@ -7,10 +7,11 @@ import {
   ScheduleTime,
   StoppingMode,
   PlaybackMode,
-  LoopMode
+  LoopMode,
+  AudioStatus
 } from './types';
 import * as Tone from 'tone';
-import { Event, Time, gainToDb } from 'tone';
+import { Event, Time, gainToDb, Emitter } from 'tone';
 import { calculateScheduleTimes, toBufferSegment } from './looping';
 import { createTonePlayer, PlayerFactory, add } from './tone-helpers';
 
@@ -55,9 +56,11 @@ export class ManagedAudioEvent implements IAudioEvent {
   private timings: LifeCycleTimings;
   private createPlayer: (startOffset?: number) => Player;
   private parameterDispatchers: Map<Parameter, ParameterStateHandling>;
+  private emitter: IEmitter<AudioStatus, number | string>;
 
   constructor({startTime, duration = 0, ...otherParams}: ManagedEventArgs) {
     const { timings = defaultTimings, createPlayer } = otherParams;
+    this.emitter = new Emitter();
     this.createPlayer = createPlayer;
     this.timings = timings;
     this.scheduled = new Map();
@@ -146,6 +149,7 @@ export class ManagedAudioEvent implements IAudioEvent {
       Tone.Transport.seconds : preLoadTime
     );
     this.scheduled.set('connect', connectAndScheduleToPlay);
+    this.emit('playing', Tone.Transport.seconds);
   }
   
   set(param: Parameter, value: number): void {
@@ -171,6 +175,26 @@ export class ManagedAudioEvent implements IAudioEvent {
   stop(time: ScheduleTime, mode: StoppingMode): void {
     // TODO stopping modes etc, clean up is different depending on mode
     this.reset();
+  }
+
+  dispose(): this {
+    this.emitter.dispose();
+    return this;
+  }
+
+  emit(event: AudioStatus, ...args: (string | number)[]): this {
+    this.emitter.emit(event, ...args);
+    return this;
+  }
+
+  off(event: AudioStatus, callback?: ((...args: (string | number)[]) => void)): this {
+    this.emitter.off(event, callback);
+    return this;
+  }
+
+  on(event: AudioStatus, callback: (...args: (string | number)[]) => void): this {
+    this.emitter.on(event, callback);
+    return this;
   }
 
   private reset() {

--- a/src/test.ts
+++ b/src/test.ts
@@ -148,6 +148,9 @@ async function testLifeCycleChangeOffsetBeforeScheduledTime() {
 
 async function testLifeCycleChangeOffsetLoopedExample() {
   const {schedulo, scheduled} = await testLoopMultipleMaxPeriod(5);
+  scheduled.forEach(obj => obj.on('playing', (n) => {
+    console.warn('connected!');
+  }));
   await schedulo.scheduleEvent(() => {
     console.warn('change start time');
     scheduled.forEach(obj => obj.set(Parameter.StartTime, 10));

--- a/src/test.ts
+++ b/src/test.ts
@@ -9,7 +9,7 @@ import {
 } from './index';
 import { ManagedAudioEvent } from './life-cycle';
 
-testLifeCycleChangeOffsetLoopedExample();
+testStateEmitter();
 
 async function testTransition() {
   let schedulo = new Schedulo();
@@ -148,8 +148,19 @@ async function testLifeCycleChangeOffsetBeforeScheduledTime() {
 
 async function testLifeCycleChangeOffsetLoopedExample() {
   const {schedulo, scheduled} = await testLoopMultipleMaxPeriod(5);
-  scheduled.forEach(obj => obj.on('playing', (n) => {
-    console.warn('connected!');
+  await schedulo.scheduleEvent(() => {
+    console.warn('change start time');
+    scheduled.forEach(obj => obj.set(Parameter.StartTime, 10));
+  }, Time.At(4.5));
+}
+
+async function testStateEmitter() {
+  const {schedulo, scheduled} = await testLoopMultipleMaxPeriod(5);
+  scheduled.forEach(obj => obj.on('playing', (time) => {
+    console.warn('playing: ', time);
+  }));
+  scheduled.forEach(obj => obj.on('stopped', (time) => {
+    console.warn('stopped: ', time);
   }));
   await schedulo.scheduleEvent(() => {
     console.warn('change start time');

--- a/src/tone-object.ts
+++ b/src/tone-object.ts
@@ -1,13 +1,15 @@
-import { Player, gainToDb } from 'tone';
+import { Player, gainToDb, Emitter } from 'tone';
 import { ScheduledObject, AudioObject, EventObject, Parameter, ScheduleTime, StoppingMode } from './types';
 
-export class TonejsScheduledObject implements ScheduledObject {
+export class TonejsScheduledObject extends Emitter implements ScheduledObject {
   constructor(
     public tonejsObject: any,
     public startTime: number | string,
     public offset?: number | string,
     public duration?: number | string,
-  ) {}
+  ) {
+    super();
+  }
 }
 
 export class TonejsAudioObject extends TonejsScheduledObject implements AudioObject {

--- a/src/types.ts
+++ b/src/types.ts
@@ -100,7 +100,10 @@ export interface ScheduledObject {
   duration?: string | number;
   //etc
 }
-export interface AudioObject extends ScheduledObject {
+
+export type AudioStatus = 'playing' | 'stopped';
+export interface AudioObject extends 
+  ScheduledObject, IEmitter<AudioStatus, number | string> {
   set(param: Parameter, value: number): void,
   ramp(param: Parameter, value: number, duration: number | string, time: number | string): void,
   stop(time: ScheduleTime, mode: StoppingMode): void


### PR DESCRIPTION
Using Tone.Emitter for the observer API, as we already have it. Basically the same API as node's EventEmitter, likely compatible with one of Rx's factory functions if a consumer of the library wanted to use it with that. 